### PR TITLE
[Add]deviseのルーティング追加、URLの変更

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,15 @@
 Rails.application.routes.draw do
-  devise_for :customers
-  devise_for :admins
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  devise_for :customers, path: 'customer', controllers: {
+  sessions:      'customer/sessions',
+  passwords:     'customer/passwords',
+  registrations: 'customer/registrations'
+  }
+
+  devise_for :admins, path: 'admin', controllers: {
+  sessions:      'admin/sessions',
+  passwords:     'admin/passwords',
+  registrations: 'admin/registrations'
+  }
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  devise_for :customers, path: 'customer', controllers: {
+  devise_for :customers, controllers: {
   sessions:      'customer/sessions',
   passwords:     'customer/passwords',
   registrations: 'customer/registrations'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   registrations: 'customer/registrations'
   }
 
-  devise_for :admins, path: 'admin', controllers: {
+  devise_for :admins, controllers: {
   sessions:      'admin/sessions',
   passwords:     'admin/passwords',
   registrations: 'admin/registrations'


### PR DESCRIPTION
deviseはcustomer/adminという2つのモデルを扱う為に、deviseディレクトリからそれぞれのディレクトリにコントローラがあることをルーティングには記載する必要がありそうです。
[参考 5. routingを設定する](https://qiita.com/Yama-to/items/54ab4ce08e126ef7dade)

　また、自動生成されるURLパターンは全て**複数形**という法則があるようで、`path:'hogehoge'`という記述により置換することが可能で、実行済みです。$ rails routesにて下の画像となることを確認しています。
[参考 URLのカスタマイズ](https://qiita.com/70yama/items/dbf428a51830e70aa9bd)

<img width="1192" alt="devise 実行前" src="https://user-images.githubusercontent.com/72348241/102326211-72ae4f00-3fc7-11eb-8dd7-a25917711687.png">
↓
<img width="1204" alt="devise 実行後" src="https://user-images.githubusercontent.com/72348241/102326218-77730300-3fc7-11eb-9e16-ec02f8c78972.png">

  確認宜しくお願いします。