### PR TITLE
「管理者側」会員一覧ページ⑨　(詳細ページ⑩へのリンク)　しげ

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -1,5 +1,9 @@
 class Admin::CustomersController < ApplicationController
+
   def index
     @customers=Customer.all
+  end
+
+  def show
   end
 end

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -15,7 +15,11 @@
           <% @customers.each do |customer| %>
             <tr>
               <td><%= customer.id %></td>
-              <td><%= customer.family_name %><%= customer.first_name %></td>
+              <td>
+                <%= link_to admin_customer_path(customer.id) do %>          <!--詳細ページのリンクを会員の名前につけました-->
+                  <%= customer.family_name %><%= customer.first_name %>
+                <% end %>
+              </td>
               <td><%= customer.email %></td>
               <td><%= customer.is_deleted %></td>
             </tr>


### PR DESCRIPTION
会員一覧ページの会員名に詳細ページに飛ぶリンクをつけました。
```ruby
<%= link_to admin_customer_path(customer.id) do %>       
      <%= customer.family_name %><%= customer.first_name %>
<% end %>
```
の部分は下の記事を参考にしています。
https://blog.yuhiisk.com/archive/2018/05/02/rails-link-to-in-tags.html