### PR TITLE
[Fix]マイページに飛んだときのURL修正

### DIFF
--- a/app/views/layouts/_header-customer.html.erb
+++ b/app/views/layouts/_header-customer.html.erb
@@ -1,6 +1,6 @@
 <span class="navbar-text">ようこそ、<%= current_customer.family_name %>さん！</span>&emsp;&emsp;
 <form class="form-inline">
-  <li class="nav-item"><%= link_to "マイページ", customers_path(current_customer.id), class: "btn btn-sm btn-outline-warning" %></li>&emsp;&emsp;
+  <li class="nav-item"><%= link_to "マイページ", customer_path, class: "btn btn-sm btn-outline-warning" %></li>&emsp;&emsp;
   <li class="nav-item"><%= link_to "商品一覧", products_path, class: "btn btn-sm btn-outline-warning" %></li>&emsp;&emsp;
   <li class="nav-item"><%= link_to "カート", cart_items_path(current_customer.id), class: "btn btn-sm btn-outline-warning" %></li>&emsp;&emsp;
   <li class="nav-item"><%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: "btn btn-sm btn-outline-warning" %></li>


### PR DESCRIPTION
Customerログイン時、マイページにヘッダーより飛ぶと`/customers.[id]`というURLになっていたので修正。
修正後は`/customers`となり、IDが表示されなくなります。