### PR TITLE
会員側　マイページ退会処理機能の追加㉕　しげ

### DIFF
--- a/app/controllers/customer/customers_controller.rb
+++ b/app/controllers/customer/customers_controller.rb
@@ -14,10 +14,23 @@ class Customer::CustomersController < ApplicationController
     redirect_to customer_path(current_customer.id)
   end
 
+  def unsubscribe
+  end
+
+  def withdraw
+    customer = Customer.find(current_customer.id)
+    customer.is_deleted = true
+    customer.update(customer_is_deleted)
+    redirect_to root_path
+  end
+
 
   private
   def customer_params
      params.require(:customer).permit(:email, :family_name, :first_name, :family_kana, :first_kana, :postal_code, :address, :tel, :is_deleted)
+  end
 
+  def customer_is_deleted
+     params.permit(:is_deleted)
   end
 end

--- a/app/controllers/customer/customers_controller.rb
+++ b/app/controllers/customer/customers_controller.rb
@@ -19,9 +19,9 @@ class Customer::CustomersController < ApplicationController
 
   def withdraw
     customer = Customer.find(current_customer.id)
-    customer.is_deleted = true
-    customer.update(customer_is_deleted)
-    redirect_to root_path
+    customer.is_deleted = true                         #退会するボタンを押したとき現在ログインしているユーザーのis_deleteカラムをtrueに変えます。
+    customer.update(customer_is_deleted)               #下で作成しているcustomer_is_deletedメソッドを呼び出しています
+    redirect_to root_path                              #今はトップページに戻ってもログインしたままですが、ホクトさんにログイン状態の権限を設定してもらう予定です。
   end
 
 
@@ -31,6 +31,6 @@ class Customer::CustomersController < ApplicationController
   end
 
   def customer_is_deleted
-     params.permit(:is_deleted)
+     params.permit(:is_deleted)                  #require(:customer)を入れるとエラーが起きます。
   end
 end

--- a/app/views/customer/customers/unsubscribe.html.erb
+++ b/app/views/customer/customers/unsubscribe.html.erb
@@ -1,0 +1,12 @@
+<main>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-12 text-center">
+        <h4>本当に退会しますか？</h4>
+        <h6>退会すると、会員登録情報や<br>これまでの購入履歴が閲覧できなくなります。<br>退会する場合は「退会する」をクリックしてください。</h6>
+        <span><%=link_to "退会しない", customer_path(current_customer.id), class:"btn btn-primary"%></span>
+        <span><%=link_to "退会する", customers_withdraw_path, class:"btn btn-danger", data:{confirm: " [確認] 退会してもよろしいですか？"},method: :patch %></span>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
退会確認ページと退会処理(論理削除)の作成をしました。
退会するを押すと　is_deleted　カラムが　true　に変化します。

リダイレクト先はホーム画面にしています。
ログイン状態のままですが、ホクトさんにログインの権限を設定してもらったのちにログアウト状態に変わります。