### PR TITLE
[Update]ページ⑯ Customerログインページ編集

### DIFF
--- a/app/views/customers/registrations/edit.html.erb
+++ b/app/views/customers/registrations/edit.html.erb
@@ -31,8 +31,4 @@
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<%= link_to "元の画面に戻る", :back %>

--- a/app/views/customers/sessions/new.html.erb
+++ b/app/views/customers/sessions/new.html.erb
@@ -1,26 +1,40 @@
-<h2>Log in</h2>
-<%= flash[:error] %>
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+<div class="container">
+  <div class="row">
+    <div class="col-6 mx-auto">
+      <h3>　<%= flash[:error] %></h3>
+      <h2>　<span class="bg-secondary text-white">会員の方はこちらからログイン<br></span>　</h2>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
+  <div class="row">
+    <div class="col-4.5 mx-auto">
+      <%= form_with model: @customer, url: new_customer_session_path, local: true do |f| %>
+        <div class="form-group text-right">
+          <%= f.label :email, "メールアドレス" %>&emsp;
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", size: "40x20" %>
+        </div>
 
-<%= render "customers/shared/links" %>
+        <div class="form-group text-right">
+          <%= f.label :password, "パスワード" %>&emsp;
+          <%= f.password_field :password, autocomplete: "current-password", size: "40x20" %>
+        </div>
+        <br>
+        <div class="form-group text-right"><%= link_to "=> パスワードを忘れた方はこちら", new_customer_password_path %></div>
+        <!-- 途中で作ったパスワード再登録ページは、ログインしていないと使えないため(emailだけで使えるとセキュリティ的にまずい)deviseのデフォルトを使用 -->
+        <div class="text-center">
+            <%= f.submit "ログイン", :class => "btn btn-primary btn-lg" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <br>
+  <div class="row">
+    <div class="col-6 mx-auto">
+      <h2>　<span class="bg-secondary text-white">登録がお済みでない方<br></span>　</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4.5 mx-auto">
+      <div class="form-group text-right"><%= link_to "こちら　", new_customer_registration_path %>から新規登録を行って下さい。</div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Customerのログインページを比較的見本に近い形で編集しました。
- 「=> パスワードを忘れた方はこちら」は、deviseのメールで送る方のデフォルトペ―ジを指定しました。
   (`customer/edit`でパスワードを編集するページはそもそもログインしていないと使えなかった)