### PR TITLE
【会員側】配達先のバリデーション

### DIFF
--- a/app/controllers/customer/receivers_controller.rb
+++ b/app/controllers/customer/receivers_controller.rb
@@ -8,8 +8,12 @@ class Customer::ReceiversController < ApplicationController
   def create
     @receiver = Receiver.new(receiver_params)
     @receiver.customer_id = current_customer.id
-    @receiver.save
-    redirect_to receivers_path
+    if @receiver.save
+      redirect_to receivers_path
+    else
+      @receivers = Receiver.where(customer_id: current_customer.id)
+      render :index
+    end
   end
 
   def edit

--- a/app/models/receiver.rb
+++ b/app/models/receiver.rb
@@ -1,3 +1,8 @@
 class Receiver < ApplicationRecord
   belongs_to :customer
+
+  validates :postal_code, presence: true, length: {is:7}, numericality: { only_integer: true }
+  validates :address, presence: true
+  validates :name, presence: true
+
 end

--- a/app/views/customer/receivers/index.html.erb
+++ b/app/views/customer/receivers/index.html.erb
@@ -12,14 +12,35 @@
           <tr>
             <td>郵便番号(ハイフンなし)</td>
             <td><%= f.text_field :postal_code %></td>
+            <td>
+              <% if @receiver.errors.any? %>
+                <% @receiver.errors.full_messages_for(:postal_code).each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              <% end %>
+            </td>
           </tr>
           <tr>
             <td>住所</td>
             <td><%= f.text_field :address %></td>
+            <td>
+              <% if @receiver.errors.any? %>
+                <% @receiver.errors.full_messages_for(:address).each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              <% end %>
+            </td>
           </tr>
           <tr>
             <td>宛名</td>
             <td><%= f.text_field :name %></td>
+            <td>
+              <% if @receiver.errors.any? %>
+                <% @receiver.errors.full_messages_for(:name).each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              <% end %>
+            </td>
           </tr>
         </table>
         <div class="col-md-3">


### PR DESCRIPTION

Receiverモデルにバリデーションを付け加えました。
新規作成のみエラー文が表示されるようになっています。
編集画面は追って作成します。

郵便番号は、「数字のみ」・「7文字」・「空欄でないこと」で制限をかけています。
住所・宛名は「空欄でないこと」です。

gemでエラー文を日本語に翻訳するものをいれてもいいかもしれません。(今回は未搭載です)

確認お願いします。