### PR TITLE
【会員側】商品一覧ページ

### DIFF
--- a/app/controllers/customer/products_controller.rb
+++ b/app/controllers/customer/products_controller.rb
@@ -2,10 +2,14 @@ class Customer::ProductsController < ApplicationController
 
   def index
     @genres = Genre.where(is_active: "有効")
+
     if params[:id]
-      @products = Product.where(genre_id: params[:id])
+      @product = Product.where(genre_id: params[:id])
+      @products = Product.where(genre_id: params[:id]).page(params[:page])
+      @genre = Genre.find(params[:id])
     else
-      @products = Product.where(genre_id: (Genre.where(is_active: "有効")))
+      @product = Product.where(genre_id: (Genre.where(is_active: "有効")))
+      @products = Product.where(genre_id: (Genre.where(is_active: "有効"))).page(params[:page])
     end
   end
 

--- a/app/views/customer/products/index.html.erb
+++ b/app/views/customer/products/index.html.erb
@@ -7,7 +7,12 @@
   </div>
 
   <div class="col-md-7">
-   <h2>商品一覧(全<%= @products.count %>件)</h2>
+    <% if params[:id] %>
+     <h2><%= @genre.type %>一覧(全<%= @product.count %>件)</h2>
+    <% else %>
+     <h2>商品一覧(全<%= @product.count %>件)</h2>
+    <% end %>
+
    <% @products.each do |product| %>
     <!--商品画像-->
     <div>
@@ -27,5 +32,5 @@
     </div>
    <% end %>
   </div>
- <%#= paginate @products %>
+ <%= paginate @products %>
  </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  # config.default_per_page = 25
+  config.default_per_page = 2
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0


### PR DESCRIPTION
ページャ実装しました。

以下変更点です。

①ページャを実装したときに、「商品一覧(全〇件)」がページに表示されている分だけになってしまうのを直しました。
有効な商品が10件の場合はページに5件表示されている場合でも「全10件」と表示されます。
無効なジャンルに紐づく商品は今まで通りカウントから除かれます。

②ジャンル検索したときに「商品一覧(全〇件)」が「ケーキ一覧(全〇件)」「ゼリー一覧(全〇件)」のような「ジャンル名一覧(全〇件)」と表示されるようにしました。

③ページに表示される件数を変更しました。検証しやすいようにお試しで2件にしているので、後で変更しましょう。