### PR TITLE
【会員側】配達先ページ㉗㉘　権限の追加　しげ

### DIFF
--- a/app/controllers/customer/receivers_controller.rb
+++ b/app/controllers/customer/receivers_controller.rb
@@ -1,8 +1,10 @@
 class Customer::ReceiversController < ApplicationController
+  before_action :authenticate_customer!
 
   def index
     @receiver = Receiver.new
     @receivers = Receiver.where(customer_id: current_customer.id)
+
   end
 
   def create
@@ -18,6 +20,9 @@ class Customer::ReceiversController < ApplicationController
 
   def edit
     @receiver = Receiver.find(params[:id])
+    unless @receiver.customer_id == current_customer.id
+      redirect_to receivers_path
+    end
   end
 
   def update


### PR DESCRIPTION
【会員側】配達先ページ㉗㉘

変更点

①【未ログイン】配達先ページ㉗㉘のURLを直入力したときに、ログインページに遷移するようにしています。

②【ログイン】他ユーザーの編集ページ㉘のURLを直入力したときに、自分の配送先一覧に遷移するようにしています。