### PR TITLE
注文商品(OrderProduct)のデータベース作成　しげ

### DIFF
--- a/app/controllers/customer/orders_controller.rb
+++ b/app/controllers/customer/orders_controller.rb
@@ -21,8 +21,16 @@ class Customer::OrdersController < ApplicationController
     @order = Order.new(orders_params)
     @order.customer_id = current_customer.id
     @order.save
-    cart = Cart.where(customer_id: current_customer.id)
-    cart.destroy_all
+    carts = Cart.where(customer_id: current_customer.id)
+    carts.each do |cart|
+      order_product = OrderProduct.new(order_product_params)
+      order_product.product_id = cart.product_id
+      order_product.order_id = @order.id
+      order_product.quantity = cart.quantity
+      order_product.tax_in_price = cart.product.tax_out_price.to_i * 1.1
+      order_product.save
+    end
+    carts.destroy_all
     redirect_to orders_thanks_path
   end
 
@@ -61,6 +69,10 @@ class Customer::OrdersController < ApplicationController
 
   def receiver_params
     params.require(:receiver).permit(:postal_code, :address, :name)
+  end
+
+  def order_product_params
+    params.permit(:product_id, :order_id, :quantity, :tax_in_price, :status)
   end
 
 end

--- a/app/views/customer/orders/index.html.erb
+++ b/app/views/customer/orders/index.html.erb
@@ -16,12 +16,12 @@
         <tbody>
         <% @orders.each do |order| %>
           <tr>
-            <td><%#= order.created_at %></td>　　　　　　　　　　                          注文日を入れます
-            <td><%#= order.postal_code %><%#= order.address %><%#= order.name %></td>　　　　配送先を入れます
-            <td><%#= order.order_product %></td>　　　　　　　　                           注文商品を入れます
-            <td><%#= order.sum %></td>　　　　　　　　　　　　　                           支払い金額を入れます
-            <td><%#= order.status %></td>　　　　　　　　　　　　                          注文ステータスを入れます
-            <td><%#= link_to "表示する", order_path(1) %></td>　　                         注文詳細画面へ遷移させるボタンを作ります
+            <td><%#= order.created_at %></td>
+            <td><%#= order.postal_code %><%#= order.address %><%#= order.name %></td>
+            <td><%#= order.order_product %></td>
+            <td><%#= order.sum %></td>
+            <td><%#= order.status %></td>
+            <td><%#= link_to "表示する", order_path(1) %></td>
           </tr>
         <% end %>
         </tbody>


### PR DESCRIPTION
注文が完了した際に、OrderProductモデルが作成されるようにしました。
rails cでモデルが作成され、各カラムに期待する値が追加されていることを確認済みです。

```
[5] pry(main)> OrderProduct.find(9)
  OrderProduct Load (0.8ms)  SELECT  "order_products".* FROM "order_products" WHERE "order_products"."id" = ? LIMIT ?  [["id", 9], ["LIMIT", 1]]
=> #<OrderProduct:0x0000000004de10d0
 id: 9,
 product_id: 1,
 order_id: 9,
 quantity: 5,
 tax_in_price: 110,
 status: "着手不可",
 created_at: Tue, 22 Dec 2020 14:58:23 UTC +00:00,
 updated_at: Tue, 22 Dec 2020 14:58:23 UTC +00:00>
[6] pry(main)> OrderProduct.find(10)                                               
  OrderProduct Load (0.2ms)  SELECT  "order_products".* FROM "order_products" WHERE "order_products"."id" = ? LIMIT ?  [["id", 10], ["LIMIT", 1]]
=> #<OrderProduct:0x0000000004f0e598
 id: 10,
 product_id: 6,
 order_id: 9,
 quantity: 3,
 tax_in_price: 330,
 status: "着手不可",
 created_at: Tue, 22 Dec 2020 14:58:24 UTC +00:00,
 updated_at: Tue, 22 Dec 2020 14:58:24 UTC +00:00>
```

これで一覧ページや詳細ページを作成できると思います。
確認お願いします。