### PR TITLE
[Add]ページ⑰新規登録　バリデーションの追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,29 @@
  @import "bootstrap";
  @import 'font-awesome-sprockets';
  @import 'font-awesome';
+
+#error_explanation {
+    width: 450px;
+    border: 2px solid red;
+    padding: 7px;
+    padding-bottom: 0;
+    margin-bottom: 20px;
+    background-color: #f0f0f0;
+}
+
+#error_explanation h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px;
+    margin-bottom: 0;
+    background-color: #c00;
+    color: #fff;
+}
+
+
+.field_with_errors {
+    padding: 2px;
+    background-color: red;
+}

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -11,6 +11,14 @@ class Customer < ApplicationRecord
 
   enum is_deleted: { 有効: false, 退会済: true }
 
+  validates :family_name, :first_name, presence: true, length: { maximum: 8 }, format: { with: /\A[ぁ-んァ-ン一-龥]/ }
+  validates :family_kana, :first_kana, presence: true, length: { maximum: 10 }, format: { with: /\A[ァ-ヶー－]+\z/ }
+  validates :address, presence: true, length: { maximum: 80 }
+  validates :postal_code, presence: true, format: { with: /\A\d{7}\z/ }
+  validates :tel, presence: true, format: { with: /\A\d{10,11}\z/ }
+  validates :password_confirmation, presence: true
+
+
   def active_for_authentication?
     super && (self.is_deleted == "有効")
   end

--- a/app/views/customers/registrations/new.html.erb
+++ b/app/views/customers/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<%= render "customers/shared/error_messages", resource: resource %>
 <div class="container">
   <br>
   <div class="row">
@@ -12,7 +13,7 @@
         <tbody>
           <tr>
             <th>名前</th>
-            <td><%= f.label :family_name, "(姓)" %></td>
+            <td>(姓)</td>
             <td><%= f.text_field :family_name, autofocus: true, autocomplete: "family_name" %></td>
             <td></td>
             <td>(名)</td>


### PR DESCRIPTION
- Customerログインページのバリデーションを実装

  - 名前：姓・名…空白不可、〜8文字、全角ひらがな・カタカナ・漢字のみ入力可
  - 名前：セイ・メイ…空白不可、〜10文字、全角カタカナのみ入力可
  - 住所…空白不可、〜80文字

  - 郵便番号…空白不可、ハイフン無し数字7桁限定
  - 電話番号…空白不可、ハイフン無し数字10,11桁限定
  - エラーメッセージは赤色にして、かつ入力枠に色を付けました。
    - エラーメッセージの日本語化も…？
   
![20201223-220629](https://user-images.githubusercontent.com/72348241/102999094-c989ca80-456b-11eb-97c6-94957eeee456.png)


