### PR TITLE
[Update]ページ⑬ 注文履歴一覧の遷移前ページによる切替

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,7 +1,7 @@
 class Admin::OrdersController < ApplicationController
 
   def top
-    @todayorder = Order.where(created_at: Time.now.all_day) #本日作成したOrderを代入
+    @todayorder = Order.where(created_at: Time.current.all_day) #本日作成したOrderを代入
   end
 
   def index

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -5,7 +5,15 @@ class Admin::OrdersController < ApplicationController
   end
 
   def index
-    @orders = Order.all
+    case params[:order_type]
+    when "today"
+      @orders = Order.where(created_at: Time.current.all_day)
+    when "customer"
+      @customer = Customer.find(params[:format])
+      @orders = @customer.orders
+    else
+      @orders = Order.all
+    end
   end
 
   def update

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -32,7 +32,7 @@
       </tr>
       <tr>
         <td><%=link_to "編集する", edit_admin_customer_path(@customer.id) %></td>
-        <td><%=link_to "注文履歴一覧を見る", admin_orders_path %></td>
+        <td><%=link_to "注文履歴一覧を見る", admin_orders_path(@customer.id, order_type: "customer") %></td>
       </tr>
     </table>
   </div>

--- a/app/views/admin/orders/top.html.erb
+++ b/app/views/admin/orders/top.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="row">
     <div class="col-5 mx-auto">
-    <h1>本日の注文件数　　　　　<%= link_to @todayorder.count, admin_orders_path, class: "text-dark" %> 件</h1>
+    <h1>本日の注文件数　　　　　<%= link_to @todayorder.count, admin_orders_path(order_type: "today"), class: "text-dark" %> 件</h1>
     <!-- admin/ordersに遷移する。 ただし、表示する内容はOrder.where(created_at: Time.now.all_day).each do |o|-->
     </div>
   </div>


### PR DESCRIPTION
- UIFlowsにおいて、admin側のorders/indexは3種類の表示の切替があるようなので、実装しました。
  1. admin/topページから今日の注文件数をクリックすると、今日の注文履歴一覧へ
  2. admin/customers/showページからユーザーの注文履歴をクリックすると、そのユーザーの注文履歴一覧へ
  3. ヘッダーから注文履歴一覧をクリックすると、注文履歴の一覧全てを表示
- admin/topページの今日の注文件数がJSTでは無かったため、メソッドを変えて修正しました。