### PR TITLE
ラジオボタンの初期値

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,4 +7,5 @@ class Order < ApplicationRecord
   # 注文ステータス
   enum status: {入金待ち: 0, 入金確認: 1, 製作中: 2, 発送準備中: 3, 発送: 4}
 
+
 end

--- a/app/views/customer/orders/new.html.erb
+++ b/app/views/customer/orders/new.html.erb
@@ -1,12 +1,12 @@
 <!--注文情報入力フォーム-->
 <%= form_with model: @order, url: orders_confirm_path, method: :get, local: true do |f| %>
   <h4>支払方法</h4>
-  <label><%= f.radio_button :payment, "銀行振込" %>銀行振込</label>
+  <label><%= f.radio_button :payment, "銀行振込", :checked => true %>銀行振込</label>
   <label><%= f.radio_button :payment, "クレジットカード" %>クレジットカード</label></br>
 
   <h4>お届け先</h4>
   <!--ご自身の住所-->
-  <label><%= radio_button_tag("select_name", 0) %>ご自身の住所</label>
+  <label><%= radio_button_tag("select_name", 0, [:checked => true]) %>ご自身の住所</label>
     <%= f.label @customer.address %></br>
   <!--登録済み住所から選択-->
   <label><%= radio_button_tag("select_name", 1) %>登録済み住所から選択</label></br>


### PR DESCRIPTION
注文情報入力フォームのラジオボタンで空きで入力できないようにするためにボタンの初期値を設定しました。