### PR TITLE
[Update](管理者)ページ⑫　注文履歴詳細画面　デザイン&変数を整数化

### DIFF
--- a/app/assets/stylesheets/admin/orders.scss
+++ b/app/assets/stylesheets/admin/orders.scss
@@ -1,3 +1,11 @@
 // Place all the styles related to the admin::orders controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.ordershow {
+  font-size: 0.8rem;
+}
+
+#order_product_status {
+    width: 100px;
+}

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,64 +1,68 @@
 <div class="container">
+  <br>
   <div class="row">
-    <div class="col-9 mx-auto">
-      <h2>　<span class="bg-secondary text-white">注文履歴詳細<br></span>　</h2>
+    <div class="col-6 mx-auto">
+      <h3><span class="bg-secondary text-white">　注文履歴詳細　<br></span></h3><br>
     </div>
   </div>
   <div class="row">
-    <div class="col-9">
-      <table class="table">
+    <div class="col-6">
+      <table class="table table-borderless">
         <tr>
           <th>購入者</th>
-          <th>配送先</th>
-          <th>支払方法</th>
-          <th>注文ステータス</th>
-          <th></th>
-        </tr>
-        <tr>
           <td>
             <%= link_to admin_customer_path(@order.customer.id) do %>
               <%= @order.customer.family_name %>　<%= @order.customer.first_name %>
             <% end %>
           </td>
-          <td>〒：<%= @order.postal_code %>　住所：<%= @order.address %>　名前：<%= @order.name %></td>
+        </tr>
+        <tr>
+          <th>配送先</th>
+          <td>〒<%= @order.postal_code %>　<%= @order.address %>　<br><%= @order.name %></td>
+        </tr>
+        <tr>
+          <th>支払い方法</th>
           <td><%= @order.payment %></td>
-          <td>保存確認：<%= @order.status %></td>
+        </tr>
+        <tr>
+          <th>注文ステータス</th>
           <td>
             <%= form_with model: @order, url: admin_order_path, method: :patch, local: true do |f| %>
-              <%= f.select :status, options_for_select(Order.statuses.keys, selected: @order.status)%>
-              <%= f.submit "更新" %>
+            <%= f.select :status, options_for_select(Order.statuses.keys, selected: @order.status), :class => "form-control" %>
+            <%= f.submit "更新", :class => "btn btn-primary btn-sm" %>
             <% end %>
           </td>
         </tr>
       </table>
     </div>
   </div>
-  <div class="row">
-    <div class="col-8">
+  <br>
+  <div class="row justify-content-between">
+    <div class="col-8 ordershow text-center">
       <table class="table">
-        <thead>
+        <thead class="thead-light">
           <tr>
-            <th>ID(test)</th>
-            <th>商品名</th>
+            <th class="text-left">商品名</th>
             <th>単価（税込）</th>
             <th>数量</th>
             <th>小計</th>
-            <th colspan="3">製作ステータス</th>
+            <th>製作ステータス</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
           <% @order_products.each do |order_product| %>
-            <tr>
-              <td>order_product.id:<%= order_product.id %></td>
-              <td><%= order_product.product.name %></td>
-              <td><%= ((order_product.product.tax_out_price).to_i * 1.1).round %></td>
-              <td><%= order_product.quantity %></td>
-              <td><%= ((order_product.product.tax_out_price).to_i * 1.1 * (order_product.quantity).to_i).round %></td>
-              <td>保存確認：<%= order_product.status %></td>
-              <td>
+            <tr></tr>
+              <td class="text-left align-middle"><%= order_product.product.name %></td>
+              <td class="align-middle"><%= ((order_product.product.tax_out_price).to_i * 1.1).round %></td>
+              <td class="align-middle"><%= order_product.quantity %></td>
+              <td class="align-middle"><%= ((order_product.product.tax_out_price).to_i * 1.1 * (order_product.quantity).to_i).round %></td>
+              <td class="align-middle">
                 <%= form_with model: order_product, url: order_creates_path(id: order_product.id), method: :patch, local: true do |f| %>
                   <%= f.select :status, options_for_select(OrderProduct.statuses.keys, selected: order_product.status)%>
-                  <%= f.submit "更新" %>
+              </td>
+              <td>
+                  <%= f.submit "更新", :class => "btn btn-primary btn-sm" %>
                 <% end %>
               </td>
             </tr>
@@ -66,20 +70,20 @@
         </tbody>
       </table>
     </div>
-    <div class="col-4 align-self-center">
+    <div class="col-3 align-self-end">
       <table class="table table-borderless">
         <tbody>
           <tr>
-            <td>商品合計：</td>
+            <th>商品合計</th>
             <td><%= @order.sum %>円</td>
           </tr>
           <tr>
-            <td>送料：</td>
+            <th>送料</th>
             <td><%= @order.shipping %>円</td>
           </tr>
           <tr>
-            <td>請求額合計：</td>
-            <td><%= @order.sum + @order.shipping %>円</td>
+            <th>請求金額合計</th>
+            <td><b><%= @order.sum.to_i + @order.shipping.to_i %>円</b></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
- 請求金額合計が文字列の足し算を行おうとしていたため、.to_iメソッドにて修正しました。
- 見本に近いデザインに調整しました。
![⑫](https://user-images.githubusercontent.com/72348241/103126361-61ed8f80-46d1-11eb-9cb9-abfa3dc0f51d.jpg)
