### PR TITLE
【会員側】購入履歴一覧ページ　見た目変更　しげ

### DIFF
--- a/app/assets/stylesheets/customer/orders.scss
+++ b/app/assets/stylesheets/customer/orders.scss
@@ -5,3 +5,10 @@
 main{
   margin-top: 40px;
 }
+
+.vvv{
+  width: 100px;
+}
+.www{
+  width: 120px;
+}

--- a/app/views/customer/orders/index.html.erb
+++ b/app/views/customer/orders/index.html.erb
@@ -1,34 +1,46 @@
-<h5>注文履歴一覧画面</h5>
-<div class="container">
-  <div class="row">
-    <div class="col-md-8 offset-md-1">
-      <table class="table">
-        <thead>
-          <tr>
-            <th>注文日</th>
-            <th>配送先</th>
-            <th>注文商品</th>
-            <th>支払金額</th>
-            <th>ステータス</th>
-            <th>注文詳細</th>
-          </tr>
-        </thead>
-        <tbody>
-        <% @order.each do |order| %>
-          <tr>
-            <td><%= order.created_at.to_s(:datetime_jp) %></td>
-            <td><%= order.postal_code %><%= order.address %><%= order.name %></td>
-            <td>
-              <% order.order_products.each do |order_product| %>
-                <%= order_product.product.name %>
-              <% end %>
-            </td>
-            <td><%= (order.sum).to_i + (order.shipping).to_i %></td>
-            <td><%= order.status %></td>
-            <td><%= link_to "表示する", order_path(order.id) %></td>
-          </tr>
-        <% end %>
-        </tbody>
+<main>
+  <div class="container">
+
+    <div class="row">
+      <div class="col-1"></div>
+      <div class="col-3">
+        <h3 class="text-center bg-light"><strong>注文履歴一覧</strong></h3>
+      </div>
     </div>
+
+    <div class="row mt-3">
+      <div class ="col-10">
+        <table class ="table table-bordered">
+          <thead class="bg-light">
+            <tr>
+              <th class="www">注文日</th>
+              <th>配送先</th>
+              <th>注文商品</th>
+              <th class="www">支払金額</th>
+              <th class="www">ステータス</th>
+              <th class="vvv">注文詳細</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @order.each do |order| %>
+              <tr>
+                <td><%= order.created_at.strftime('%Y/%m/%d') %></td>
+                <td>〒<%= order.postal_code %><br><%= order.address %><br><%= order.name %></td>
+                <td>
+                  <% order.order_products.each do |order_product| %>
+                    <li><%= order_product.product.name %></li>
+                  <% end %>
+                </td>
+                <td class="text-right"><%= (order.sum).to_i + (order.shipping).to_i %> 円</td>
+                <td><%= order.status %></td>
+                <td class="text-center"><%= link_to "表示する", order_path(order.id), class: "btn btn-primary btn-sm" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
   </div>
-</div>
+</main>
+


### PR DESCRIPTION
２９ページの購入履歴一覧ページの見た目と表記を変更しました。
![スクリーンショット (11)](https://user-images.githubusercontent.com/73116792/103128167-877d9780-46d7-11eb-8b49-50478a4ace17.png)
